### PR TITLE
Allow to use array in store

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -298,7 +298,7 @@ function createGettersAndMutationProxyFromState({ cls, proxy, state, $store, nam
     if (currentField.length && !currentField.endsWith(".")) currentField += ".";
     const path = currentField + field;
 
-    if ( maxDepth === 0 || typeof value !== "object" ) {
+    if ( maxDepth === 0 || typeof value !== "object" || Array.isArray(value)) {
 
       if( !strict || fieldIsSubmodule ) {
         


### PR DESCRIPTION
Currently in v2, the `createGettersAndMutationProxyFromState` function will try to recurse even if the field is an array.