### PR TITLE
Fix createProxy call in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ export const store = new Vuex.Store({
 
 // Creating proxies.
 const vxm = {
-  user: createProxy( UserStore ),
+  user: createProxy( store, UserStore ),
 }
 ```
 


### PR DESCRIPTION
According to `proxy.d.ts` it takes two parameters, `$store: any` being the first