### PR TITLE
Fix $subscribe and $subscribeAction return types

### DIFF
--- a/dist/interfaces.d.ts
+++ b/dist/interfaces.d.ts
@@ -70,8 +70,8 @@ export interface ProxyWatchers {
         deep: boolean;
         immediate: boolean;
     }): () => void;
-    $subscribe(mutationfield: string, callback: (payload: any) => void): void;
-    $subscribeAction(actionField: string, callbackOrObj: SubScribeActionCallback | SubScribeActionObject): void;
+    $subscribe(mutationfield: string, callback: (payload: any) => void): () => void;
+    $subscribeAction(actionField: string, callbackOrObj: SubScribeActionCallback | SubScribeActionObject): () => void;
 }
 declare type SubScribeActionCallback = (payload: any) => void;
 declare type SubScribeActionObject = {

--- a/js/interfaces.d.ts
+++ b/js/interfaces.d.ts
@@ -70,8 +70,8 @@ export interface ProxyWatchers {
         deep: boolean;
         immediate: boolean;
     }): () => void;
-    $subscribe(mutationfield: string, callback: (payload: any) => void): void;
-    $subscribeAction(actionField: string, callbackOrObj: SubScribeActionCallback | SubScribeActionObject): void;
+    $subscribe(mutationfield: string, callback: (payload: any) => void): () => void;
+    $subscribeAction(actionField: string, callbackOrObj: SubScribeActionCallback | SubScribeActionObject): () => void;
 }
 declare type SubScribeActionCallback = (payload: any) => void;
 declare type SubScribeActionObject = {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -96,9 +96,9 @@ export interface ProxyWatchers {
   $subscribe (
     mutationfield :string,
     callback :( payload :any ) => void,
-  ) :void
+  ) :() => void
 
-  $subscribeAction ( actionField :string, callbackOrObj :SubScribeActionCallback | SubScribeActionObject ) :void
+  $subscribeAction ( actionField :string, callbackOrObj :SubScribeActionCallback | SubScribeActionObject ) :() => void
 
 }
 


### PR DESCRIPTION
These methods return the result of `$store.subscribe` and `$store.subscribeAction` respectively, which return an unsubscribe function