### PR TITLE
Fixed action/mutation/getter proxies on submodules

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -18,14 +18,13 @@ export function action(...params:any[]) {
   
   if( firstParam === undefined ) return handleMutateActionMode;
   
-  if( firstParam instanceof VuexModule || firstParam instanceof LegacyVuexModule || typeof firstParam === "object" ) { 
+  if( firstParam instanceof VuexModule || firstParam instanceof LegacyVuexModule ) { 
     return handleMutateActionMode( firstParam, params[ 1 ], params[ 2 ] )
   }
-  //@ts-ignore
   switch( firstParam.mode ) {
     case "raw": return handleRawActionMode;
     case "mutate": return handleMutateActionMode;
-    default: return handleMutateActionMode;
+    default: return handleMutateActionMode( firstParam, params[ 1 ], params[ 2 ] );
   }
 
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -108,7 +108,10 @@ export function getNamespacedPath( cls :VuexModuleConstructor ) {
   
   const namespaced = cls.prototype.__options__ && cls.prototype.__options__.namespaced;
 
-  if( namespaced ) cls.prototype.__namespacedPath__ = namespaced.split("/")[0]
+  if( namespaced ) {
+    const namePaths = namespaced.split("/");
+    cls.prototype.__namespacedPath__ = namePaths[namePaths.length - 1] || namePaths[namePaths.length - 2];
+  }
 
   return cls.prototype.__namespacedPath__;
   

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ export function toCamelCase(str :string){
 }
 
 export function getClassPath( path :string ) {
+  if (!path) { return ''; }
   const arr = path.split( "/" );
   return arr[ arr.length - 1 ];
 }

--- a/test/create-proxy.spec.ts
+++ b/test/create-proxy.spec.ts
@@ -2,7 +2,7 @@
 import Vuex, {Store} from 'vuex'
 // @ts-ignore
 import { createLocalVue } from '@vue/test-utils'
-import { Module, VuexModule, getter, mutation, action } from '../src'
+import { Module, VuexModule, getter, mutation, action, getRawActionContext } from '../src'
 
 
 interface Name {

--- a/test/extract-vuex-module.spec.ts
+++ b/test/extract-vuex-module.spec.ts
@@ -90,7 +90,7 @@ describe('ExtractVuexModule', () => {
 	it('should extract all properties as state in a function for NuxtUserStore', () => {
 		const { state } = NuxtUserStore.ExtractVuexModule( NuxtUserStore );
 		expect( typeof state ).toBe( "function" );
-		expect( state() ).toEqual({
+		expect( (state as Function)() ).toEqual({
 			firstname: "Michael",
 			lastname: "Olofinjana",
 			speciality: "JavaScript",
@@ -103,7 +103,7 @@ describe('ExtractVuexModule', () => {
 		const { getters } = UserStore.ExtractVuexModule(UserStore)
 		// Note all states are automatically accessible as getters.
 		// This makes th `@getter` decorator redundant. But we have it for backwards compatibility.
-		expect(Object.keys(getters)).toEqual([ 'fullName', `__${UserStore.name.toLowerCase()}_internal_getter__` ])
+		expect(Object.keys(getters)).toEqual([ 'fullName', 'speciality', 'occupation', `__${UserStore.name.toLowerCase()}_internal_getter__` ])
 	})
 
 	it('should extract all actions', () => {


### PR DESCRIPTION
Fixes #55, fixes #58

This has been tested through usage in a professional project that uses this lib (for which we were using v2.1 before creating the fix) and in https://github.com/tiagoroldao/note-trainer

Caveats/observations:
- This **may** also fix other naming related issues?
- Tests are passing ✅ 
- Some of the issues found/regressed to while attempting to track the issue #55 were to do with some confusion around supporting **both** old and new APIs 
  - The tests seem to check old usage mostly (using `@Module` annotations) still