### PR TITLE
Fix for internal proxy

### DIFF
--- a/js/proxy.js
+++ b/js/proxy.js
@@ -195,7 +195,6 @@ function createSubModuleProxy($store, cls, proxy, modules) {
     var store = cls.prototype.__store_cache__ || $store;
     for (var field in modules) {
         var subModuleClass = cls.prototype.__submodules_cache__[field];
-        subModuleClass.prototype.__namespacedPath__ = cls.prototype.__namespacedPath__ + "/" + subModuleClass.prototype.__namespacedPath__;
         proxy[field] = createProxy(store, subModuleClass);
     }
 }


### PR DESCRIPTION
When creating internal proxies on submodules, they were generating the namespaced path twice.

Eg a module of 'user' with a submodule of 'settings' would generate a namespace path of 'user/user/settings'.

When trying to access local mutations, it is generating an error.

This resolves it by removing the double up.