### PR TITLE
Fix strict test

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,7 +2,17 @@ import { extractVuexModule, getNamespacedPath } from "./module";
 import { VuexModuleConstructor, Map, VuexModule, ProxyWatchers } from "./interfaces";
 import { getClassPath, toCamelCase, refineNamespacedPath } from "./utils";
 
-export function clearProxyCache<T extends typeof VuexModule>( cls :T ) {}
+export function clearProxyCache<T extends typeof VuexModule>( cls :T ) {
+  //@ts-ignore
+  const VuexClass = cls as VuexModuleConstructor
+  delete VuexClass.prototype.__vuex_module_cache__
+  delete VuexClass.prototype.__vuex_proxy_cache__
+  delete VuexClass.prototype.__store_cache__
+  delete VuexClass.prototype.__vuex_local_proxy_cache__
+  for (const submodule of Object.values(VuexClass.prototype.__submodules_cache__)) {
+    clearProxyCache(submodule)
+  }
+}
 
 export function createProxy<T extends typeof VuexModule>( $store :any, cls :T ) :ProxyWatchers & InstanceType<T> {
   //@ts-ignore

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -305,18 +305,25 @@ function createGettersAndMutationProxyFromState({ cls, proxy, state, $store, nam
 
     if ( maxDepth === 0 || typeof value !== "object" || (typeof value === 'object' && !fieldIsSubmodule) ) {
 
+      const getter = () => { 
+        // When creating local proxies getters doesn't exist on that context, so we have to account
+        // for that.
+        let getters = namespacedPath ? $store.rootGetters : $store.getters
+        if (getters === undefined) {
+          if ($store.getters === undefined) {
+            namespacedPath = ""
+            getters = $store
+          } else {
+            getters = $store.getters
+          }
+        }
+        return getters[ `${namespacedPath}__${className}_internal_getter__` ]( path )
+      }
+
       if( !strict || fieldIsSubmodule ) {
         
         Object.defineProperty(proxy, field, {
-          get: () => { 
-            // When creating local proxies getters doesn't exist on that context, so we have to account
-            // for that.
-            const getters = cls.prototype.__namespacedPath__ ? $store.rootGetters : $store.getters;
-            if( getters ) {
-              const getterPath = refineNamespacedPath(cls.prototype.__namespacedPath__) + `__${className}_internal_getter__`;
-              return getters[ getterPath ]( path )
-            }else return $store[ `__${className}_internal_getter__` ]( path ) 
-          },
+          get: getter,
           set: payload => { 
             const commit = $store.commit || cls.prototype.__store_cache__.commit;
             if( commit ) commit( refineNamespacedPath( cls.prototype.__namespacedPath__ ) + `__${className}_internal_mutator__`, { field: path, payload }, { root: true });
@@ -333,13 +340,7 @@ function createGettersAndMutationProxyFromState({ cls, proxy, state, $store, nam
       else {
 
         Object.defineProperty(proxy, field, {
-          get: () => { 
-            // When creating local proxies getters doesn't exist on that context, so we have to account
-            // for that.
-            if( $store.getters ) { 
-              return $store.getters[ namespacedPath + `__${className}_internal_getter__` ]( path )
-            }else return $store[ `__${className}_internal_getter__` ]( path ) 
-          },
+          get: getter,
         })
 
       }
@@ -463,15 +464,26 @@ function createGettersAndGetterMutationsProxy({ cls, getters, mutations, proxy, 
 
     if( $store === undefined || proxy[ field ] ) continue;
 
+    const getter = () => { 
+      // When creating local proxies getters doesn't exist on that context, so we have to account
+      // for that.
+      let getters = namespacedPath ? $store.rootGetters : $store.getters
+      if (getters === undefined) {
+        if ($store.getters === undefined) {
+          namespacedPath = ""
+          getters = $store
+        } else {
+          getters = $store.getters
+        }
+      }
+      return getters[ `${namespacedPath}${field}` ]
+    }
+
     const fieldHasGetterAndMutation = getterMutations.indexOf( field ) > -1;
     if( fieldHasGetterAndMutation ) {
       
       Object.defineProperty( proxy, field, {
-        get: () => {
-          const storeGetters = namespacedPath ? $store.rootGetters : $store.getters;
-          if( storeGetters ) return storeGetters[ namespacedPath + field ]
-          else return $store[ namespacedPath + field ];
-        },
+        get: getter,
         set: ( payload :any ) => $store.commit( namespacedPath + field, payload, { root: !!namespacedPath } ),
       })
       
@@ -482,13 +494,7 @@ function createGettersAndGetterMutationsProxy({ cls, getters, mutations, proxy, 
     if( Object.prototype.hasOwnProperty.call(proxy, field) ) continue;
     
     Object.defineProperty( proxy, field, {
-      get: () => { 
-        const storeGetters = namespacedPath ? $store.rootGetters : $store.getters;
-        if (storeGetters)
-            return storeGetters[ namespacedPath + field ];
-        else
-            return $store[ namespacedPath + field ];
-      }
+      get: getter
     })
 
   }

--- a/test/create-proxy.spec.ts
+++ b/test/create-proxy.spec.ts
@@ -30,7 +30,7 @@ class Books extends createModule({ namespaced: 'books/' }) {
 	}
 }
 
-class UserStore extends createModule({ namespaced: 'user/' })  {
+class UserStore extends createModule({ namespaced: 'user/', strict: false })  {
 
 	settings = createSubModule(UserSettings)
 	something = createSubModule(Something)
@@ -91,11 +91,11 @@ describe('CreateProxy', () => {
 		localVue = createLocalVue()
 		localVue.use(Vuex)
 		store = new Store({
+			strict: true,
 			modules: {
 				...extractVuexModule(UserStore)
 			}
 		})
-		// console.log('New store with UserStore', store.getters)
 	})
 
 	afterEach(() => {
@@ -144,6 +144,17 @@ describe('CreateProxy', () => {
 
 		expect(user.fullName).toEqual('Ola Nordmann')
 
+		expect(user.firstname).toEqual('Ola')
+		expect(user.lastname).toEqual('Nordmann')
+	})
+
+	it('should proxy non-strict setter in strict mode', () => {
+		const user = createProxy(store, UserStore)
+
+		expect(user.firstname).toEqual('Michael')
+		expect(user.lastname).toEqual('Olofinjana')
+		user.firstname = 'Ola'
+		user.lastname = 'Nordmann'
 		expect(user.firstname).toEqual('Ola')
 		expect(user.lastname).toEqual('Nordmann')
 	})


### PR DESCRIPTION
This is a continuation of #77 

In this one, I enabled strict mode for Vuex, and set the `strict` option of VuexModule to false, to enable automatic setters.
I had to implement `clearProxyCache`, because otherwise, previously defined modules, watchers and other things were conflicting.

Be careful, I also clean `__vuex_module_cache__` in this one. In fact, the best way for tests should be to have access to `initializeModuleInternals`, but I don't know if it is meant to be used like this.