### PR TITLE
Fix local watcher example

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ export class UserStore extends VuexModule.With({ namespaced: "user" }) {
     return this.firstname + " " + this.lastname;
   }
 
-  $watch = {
+  static $watch = {
     fullname( newValue ) { console.log( `Fullname has changed ${newValue}` },
   }
 


### PR DESCRIPTION
If the `$watch` is not static, then it is part of the object constructor in TypeScript and not part of the object prototype, so it can't be accessed from [`createLocalWatchers`](https://github.com/michaelolof/vuex-class-component/blob/master/src/proxy.ts#L222).